### PR TITLE
Integrate mars-photo-sdk throughout application

### DIFF
--- a/app/(with-header-footer)/favourites/page.tsx
+++ b/app/(with-header-footer)/favourites/page.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import {useReadLocalStorage} from '@/app/hooks/useReadLocalStorage'
 import PhotoThumbnail from '@/app/ui/photo-thumbnail'
 import PhotoGrid from '@/app/ui/PhotoGrid'
-import {Photo} from '@/types/APIResponseTypes'
+import type {Photo} from 'mars-photo-sdk'
 
 export default function FavouritePhotos() {
   const favourites = useReadLocalStorage<Photo[]>('favourites')
@@ -20,7 +20,7 @@ export default function FavouritePhotos() {
         <PhotoThumbnail
           key={photo.id}
           photo={photo}
-          searchParams={{id: photo.id}}
+          searchParams={{id: String(photo.id)}}
         />
       ))}
     </PhotoGrid>

--- a/app/(with-header-footer)/manifests/[rover]/page.tsx
+++ b/app/(with-header-footer)/manifests/[rover]/page.tsx
@@ -28,24 +28,24 @@ export default async function Page({params}: {params: {rover: RoverName}}) {
         </p>
         <div className="flex flex-wrap justify-center gap-4 capitalize">
           {Object.entries(manifest).map(([key, value]) => {
-            if (key !== 'photos') {
-              if (key === 'max_sol' || key === 'total_photos') {
+            if (key !== 'photos' && value !== undefined) {
+              if (key === 'max_sol' || key === 'maxSol' || key === 'total_photos' || key === 'totalPhotos') {
                 value = new Intl.NumberFormat().format(value as number)
               }
 
               if (
-                key === 'max_date' ||
-                key === 'launch_date' ||
-                key === 'landing_date'
+                key === 'max_date' || key === 'maxDate' ||
+                key === 'launch_date' || key === 'launchDate' ||
+                key === 'landing_date' || key === 'landingDate'
               ) {
                 value = format(new Date(value as string), 'do MMM yyyy')
               }
 
-              return key === 'total_photos' ? (
-                <Link href={`/manifests/${manifest.name}/photos`}>
-                  <Card key={value as string}>
+              return key === 'total_photos' || key === 'totalPhotos' ? (
+                <Link href={`/manifests/${manifest.name}/photos`} key={key}>
+                  <Card>
                     <CardHeader>
-                      <CardTitle>{key.split('_').join(' ')}</CardTitle>
+                      <CardTitle>{key.split(/[_]|(?=[A-Z])/).join(' ')}</CardTitle>
                     </CardHeader>
                     <CardContent className="text-center">
                       {value as string | number}
@@ -53,9 +53,9 @@ export default async function Page({params}: {params: {rover: RoverName}}) {
                   </Card>
                 </Link>
               ) : (
-                <Card key={value as string}>
+                <Card key={key}>
                   <CardHeader>
-                    <CardTitle>{key.split('_').join(' ')}</CardTitle>
+                    <CardTitle>{key.split(/[_]|(?=[A-Z])/).join(' ')}</CardTitle>
                   </CardHeader>
                   <CardContent className="text-center">
                     {value as string | number}

--- a/app/(with-header-footer)/manifests/[rover]/photos/columns.tsx
+++ b/app/(with-header-footer)/manifests/[rover]/photos/columns.tsx
@@ -2,11 +2,11 @@
 
 import {ColumnDef} from '@tanstack/react-table'
 import {format} from 'date-fns'
+import type {ManifestPhoto} from 'mars-photo-sdk'
 
 import {DataTableColumnHeader} from '@/app/ui/data-table-column-header'
-import {PhotoManifestEntry} from '@/types/APIResponseTypes'
 
-export const columns: ColumnDef<PhotoManifestEntry>[] = [
+export const columns: ColumnDef<ManifestPhoto>[] = [
   {
     accessorKey: 'sol',
     header: ({column}) => <DataTableColumnHeader column={column} title="Sol" />,
@@ -24,8 +24,11 @@ export const columns: ColumnDef<PhotoManifestEntry>[] = [
       <DataTableColumnHeader column={column} title="Earth Date" />
     ),
     cell: ({row}) => {
+      const earthDate = row.getValue('earth_date') as string | undefined
+      if (!earthDate) return <div>-</div>
+
       const formattedDate = format(
-        new Date(row.getValue('earth_date')),
+        new Date(earthDate),
         'do MMM yyyy',
       )
 
@@ -38,9 +41,10 @@ export const columns: ColumnDef<PhotoManifestEntry>[] = [
       <DataTableColumnHeader column={column} title="Total" />
     ),
     cell: ({row}) => {
-      const formattedNumber = new Intl.NumberFormat().format(
-        row.getValue('total_photos'),
-      )
+      const totalPhotos = row.getValue('total_photos') as number | undefined
+      if (totalPhotos === undefined) return <div>-</div>
+
+      const formattedNumber = new Intl.NumberFormat().format(totalPhotos)
 
       return <div>{formattedNumber}</div>
     },

--- a/app/(with-header-footer)/manifests/columns.tsx
+++ b/app/(with-header-footer)/manifests/columns.tsx
@@ -5,9 +5,9 @@ import {format} from 'date-fns'
 
 import {statuses} from '@/app/(with-header-footer)/manifests/data-table'
 import {DataTableColumnHeader} from '@/app/ui/data-table-column-header'
-import {PhotoManifest} from '@/types/APIResponseTypes'
+import type {Manifest} from 'mars-photo-sdk'
 
-export const columns: ColumnDef<PhotoManifest>[] = [
+export const columns: ColumnDef<Manifest>[] = [
   {
     accessorKey: 'name',
     header: ({column}) => (
@@ -20,8 +20,11 @@ export const columns: ColumnDef<PhotoManifest>[] = [
       <DataTableColumnHeader column={column} title="Landing Date" />
     ),
     cell: ({row}) => {
+      const landingDate = row.getValue('landing_date') as string | undefined
+      if (!landingDate) return <div>-</div>
+
       const formattedDate = format(
-        new Date(row.getValue('landing_date')),
+        new Date(landingDate),
         'do MMM yyyy',
       )
 
@@ -34,8 +37,11 @@ export const columns: ColumnDef<PhotoManifest>[] = [
       <DataTableColumnHeader column={column} title="Launch Date" />
     ),
     cell: ({row}) => {
+      const launchDate = row.getValue('launch_date') as string | undefined
+      if (!launchDate) return <div>-</div>
+
       const formattedDate = format(
-        new Date(row.getValue('launch_date')),
+        new Date(launchDate),
         'do MMM yyyy',
       )
 
@@ -75,9 +81,10 @@ export const columns: ColumnDef<PhotoManifest>[] = [
       <DataTableColumnHeader column={column} title="Max Sol" />
     ),
     cell: ({row}) => {
-      const formattedNumber = new Intl.NumberFormat().format(
-        row.getValue('max_sol'),
-      )
+      const maxSol = row.getValue('max_sol') as number | undefined
+      if (maxSol === undefined) return <div>-</div>
+
+      const formattedNumber = new Intl.NumberFormat().format(maxSol)
 
       return <div>{formattedNumber}</div>
     },
@@ -88,8 +95,11 @@ export const columns: ColumnDef<PhotoManifest>[] = [
       <DataTableColumnHeader column={column} title="Max Date" />
     ),
     cell: ({row}) => {
+      const maxDate = row.getValue('max_date') as string | undefined
+      if (!maxDate) return <div>-</div>
+
       const formattedDate = format(
-        new Date(row.getValue('max_date')),
+        new Date(maxDate),
         'do MMM yyyy',
       )
 
@@ -102,9 +112,10 @@ export const columns: ColumnDef<PhotoManifest>[] = [
       <DataTableColumnHeader column={column} title="Total Photos" />
     ),
     cell: ({row}) => {
-      const formattedNumber = new Intl.NumberFormat().format(
-        row.getValue('total_photos'),
-      )
+      const totalPhotos = row.getValue('total_photos') as number | undefined
+      if (totalPhotos === undefined) return <div>-</div>
+
+      const formattedNumber = new Intl.NumberFormat().format(totalPhotos)
 
       return <div>{formattedNumber}</div>
     },

--- a/app/(with-header-footer)/search/[rover]/[date]/[camera]/page.tsx
+++ b/app/(with-header-footer)/search/[rover]/[date]/[camera]/page.tsx
@@ -61,7 +61,7 @@ export default async function Page({
           <PhotoThumbnail
             key={photo.id}
             photo={photo}
-            searchParams={{rover, date, camera, page, id: photo.id}}
+            searchParams={{rover, date, camera, page, id: String(photo.id)}}
           />
         ))}
       </PhotoGrid>

--- a/app/(with-header-footer)/search/[rover]/[date]/page.tsx
+++ b/app/(with-header-footer)/search/[rover]/[date]/page.tsx
@@ -51,7 +51,7 @@ export default async function Page({
           <PhotoThumbnail
             key={photo.id}
             photo={photo}
-            searchParams={{rover, date, page, id: photo.id}}
+            searchParams={{rover, date, page, id: String(photo.id)}}
           />
         ))}
       </PhotoGrid>

--- a/app/(with-header-footer)/search/[rover]/page.tsx
+++ b/app/(with-header-footer)/search/[rover]/page.tsx
@@ -27,7 +27,7 @@ export default async function Page({params}: {params: {rover: RoverName}}) {
         <PhotoThumbnail
           key={photo.id}
           photo={photo}
-          searchParams={{rover, id: photo.id}}
+          searchParams={{rover, id: String(photo.id)}}
         />
       ))}
     </PhotoGrid>

--- a/app/(with-header-footer)/search/ui/PhotosNotFound.tsx
+++ b/app/(with-header-footer)/search/ui/PhotosNotFound.tsx
@@ -13,12 +13,12 @@ export default async function PhotosNotFound({rover}: {rover: RoverName}) {
         No photos found. It&apos;s possible no photos were taken on that day or
         by that camera, or both.
       </p>
-      {manifest && (
+      {manifest && manifest.landing_date && manifest.max_date && (
         <p className="max-w-prose">
           Note, the landing date for {rover} is{' '}
-          {format(parseISO(manifest?.landing_date), 'do LLLL yyyy')}, and the
+          {format(parseISO(manifest.landing_date), 'do LLLL yyyy')}, and the
           max Earth date is{' '}
-          {format(parseISO(manifest?.max_date), 'do LLLL yyyy')}.
+          {format(parseISO(manifest.max_date), 'do LLLL yyyy')}.
         </p>
       )}
     </div>

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1,10 +1,10 @@
-import {isSolDate} from '@/app/(with-header-footer)/search/utils/date'
-import {
-  CameraName,
-  Photo,
-  PhotoManifest,
-  RoverName,
-} from '@/types/APIResponseTypes'
+import {MarsPhotosClient, type Photo, type Manifest} from 'mars-photo-sdk'
+import type {CameraName, RoverName} from '@/types/APIResponseTypes'
+
+const client = new MarsPhotosClient({
+  apiKey: String(process.env.NASA_API_KEY),
+  baseUrl: String(process.env.NASA_BASE_URL),
+})
 
 export const getPhotos = async ({
   rover,
@@ -17,69 +17,24 @@ export const getPhotos = async ({
   camera?: CameraName
   page: string
 }): Promise<Photo[]> => {
-  const params = new URLSearchParams()
+  const response = await client.photos.get({
+    rover: rover.toLowerCase() as Lowercase<RoverName>,
+    date,
+    camera,
+    page: parseInt(page, 10),
+  })
 
-  params.set('api_key', String(process.env.NASA_API_KEY))
-
-  if (isSolDate(date)) {
-    params.set('sol', date)
-  } else {
-    params.set('earth_date', date)
-  }
-
-  if (camera) {
-    params.set('camera', camera)
-  }
-  params.set('page', String(page))
-
-  const res = await fetch(
-    `${process.env.NASA_BASE_URL}/rovers/${rover}/photos?${params.toString()}`,
-  )
-
-  if (!res.ok) {
-    throw new Error('Failed to fetch data')
-  }
-
-  const {photos} = await res.json()
-
-  return photos
+  return response
 }
 
 export const getMissionManifest = async (
   rover: RoverName,
-): Promise<PhotoManifest> => {
-  const res = await fetch(
-    `${process.env.NASA_BASE_URL}/manifests/${rover}?api_key=${String(
-      process.env.NASA_API_KEY,
-    )}`,
-    {cache: 'no-store'},
-  )
-
-  if (!res.ok) {
-    throw new Error('Failed to fetch data')
-  }
-
-  const {photo_manifest} = await res.json()
-
-  return photo_manifest
+): Promise<Manifest> => {
+  return await client.manifests.get(rover.toLowerCase() as Lowercase<RoverName>)
 }
 
 export const getLatestPhotos = async (rover: RoverName): Promise<Photo[]> => {
-  const params = new URLSearchParams()
-  params.set('api_key', String(process.env.NASA_API_KEY))
-
-  const res = await fetch(
-    `${
-      process.env.NASA_BASE_URL
-    }/rovers/${rover}/latest_photos?${params.toString()}`,
-    {cache: 'no-store'},
+  return await client.photos.getLatest(
+    rover.toLowerCase() as Lowercase<RoverName>,
   )
-
-  if (!res.ok) {
-    throw new Error('Failed to fetch data')
-  }
-
-  const {latest_photos} = await res.json()
-
-  return latest_photos
 }

--- a/app/photo/favourites/page.tsx
+++ b/app/photo/favourites/page.tsx
@@ -63,8 +63,10 @@ export default function FavouritePhotoPage({
 
   useEffect(() => {
     if (!photo) return
+    const imgSrc = photo.img_src || photo.imgSrc
+    if (!imgSrc) return
 
-    loadImage(setImageDimensions, photo.img_src)
+    loadImage(setImageDimensions, imgSrc)
   }, [photo])
 
   const toggleSidebar = () => {
@@ -106,7 +108,7 @@ export default function FavouritePhotoPage({
             photo={photo}
           />
           <NextImage
-            src={photo.img_src}
+            src={photo.img_src || photo.imgSrc || ''}
             alt={`Photo ${photo.id.toString()} taken by Mars Rover ${
               photo.rover.name
             } on sol ${photo.sol}.`}
@@ -133,7 +135,7 @@ export default function FavouritePhotoPage({
         photo={photo}
       />
       <NextImage
-        src={photo.img_src}
+        src={photo.img_src || photo.imgSrc || ''}
         alt={`Photo ${photo.id.toString()} taken by Mars Rover ${
           photo.rover.name
         } on sol ${photo.sol}.`}

--- a/app/photo/page.tsx
+++ b/app/photo/page.tsx
@@ -3,7 +3,8 @@ import sharp from 'sharp'
 
 import {getLatestPhotos, getPhotos} from '@/app/lib/api'
 import PhotoPage from '@/app/photo/ui/PhotoPage'
-import {CameraName, Photo, RoverName} from '@/types/APIResponseTypes'
+import type {Photo} from 'mars-photo-sdk'
+import {CameraName, RoverName} from '@/types/APIResponseTypes'
 
 export type SearchParams = {
   id: string
@@ -63,7 +64,8 @@ export default async function Page({
 
   const photosWithDimensions = await Promise.all(
     (photos as PhotoWithDimensions[]).map(async photo => {
-      photo.dimensions = await loadImage(photo.img_src)
+      const imgSrc = photo.img_src || photo.imgSrc || ''
+      photo.dimensions = await loadImage(imgSrc)
 
       return photo
     }),

--- a/app/photo/ui/PhotoPage.tsx
+++ b/app/photo/ui/PhotoPage.tsx
@@ -56,7 +56,7 @@ export default function PhotoPage({
             photo={photo}
           />
           <Image
-            src={photo.img_src}
+            src={photo.img_src || photo.imgSrc || ''}
             alt={`Photo ${photo.id.toString()} taken by Mars Rover ${
               photo.rover.name
             } on sol ${photo.sol}.`}
@@ -83,7 +83,7 @@ export default function PhotoPage({
         photo={photo}
       />
       <Image
-        src={photo.img_src}
+        src={photo.img_src || photo.imgSrc || ''}
         alt={`Photo ${photo.id.toString()} taken by Mars Rover ${
           photo.rover.name
         } on sol ${photo.sol}.`}

--- a/app/photo/ui/PhotoSidebar.tsx
+++ b/app/photo/ui/PhotoSidebar.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import {format, parseISO} from 'date-fns'
 import {useMediaQuery} from 'usehooks-ts'
 
-import {Photo} from '@/types/APIResponseTypes'
+import type {Photo} from 'mars-photo-sdk'
 
 export default function PhotoSidebar({
   isOpen,
@@ -37,19 +37,25 @@ export default function PhotoSidebar({
 
       <div className="prose">
         <h1 className="mb-4 text-xl">Info</h1>
-        <p>Photo date: {format(parseISO(photo.earth_date), 'do LLLL yyyy')}</p>
-        <p>Camera: {photo.camera.full_name}</p>
+        {(photo.earth_date || photo.earthDate) && (
+          <p>Photo date: {format(parseISO(photo.earth_date || photo.earthDate || ''), 'do LLLL yyyy')}</p>
+        )}
+        <p>Camera: {photo.camera.full_name || photo.camera.fullName}</p>
         <p>Rover: {photo.rover.name}</p>
         <p>Status: {photo.rover.status}</p>
 
-        <p>
-          Launch date:{' '}
-          {format(parseISO(photo.rover.launch_date), 'do LLLL yyyy')}
-        </p>
-        <p>
-          Landing date:{' '}
-          {format(parseISO(photo.rover.landing_date), 'do LLLL yyyy')}
-        </p>
+        {(photo.rover.launch_date || photo.rover.launchDate) && (
+          <p>
+            Launch date:{' '}
+            {format(parseISO(photo.rover.launch_date || photo.rover.launchDate || ''), 'do LLLL yyyy')}
+          </p>
+        )}
+        {(photo.rover.landing_date || photo.rover.landingDate) && (
+          <p>
+            Landing date:{' '}
+            {format(parseISO(photo.rover.landing_date || photo.rover.landingDate || ''), 'do LLLL yyyy')}
+          </p>
+        )}
       </div>
     </div>
   )

--- a/app/ui/ButtonFavourite.tsx
+++ b/app/ui/ButtonFavourite.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import React, {useState} from 'react'
 import {useLocalStorage} from 'usehooks-ts'
 
-import {Photo} from '@/types/APIResponseTypes'
+import type {Photo} from 'mars-photo-sdk'
 
 export default function ButtonFavourite({
   photo,
@@ -55,6 +55,6 @@ export default function ButtonFavourite({
   )
 }
 
-function isFavouritePhoto(favourites: Photo[], id: string) {
+function isFavouritePhoto(favourites: Photo[], id: number) {
   return favourites.some(photo => photo.id === id)
 }

--- a/app/ui/photo-thumbnail.tsx
+++ b/app/ui/photo-thumbnail.tsx
@@ -3,7 +3,8 @@ import Link from 'next/link'
 import React from 'react'
 
 import ButtonFavourite from '@/app/ui/ButtonFavourite'
-import {CameraName, Photo, RoverName} from '@/types/APIResponseTypes'
+import type {Photo} from 'mars-photo-sdk'
+import {CameraName, RoverName} from '@/types/APIResponseTypes'
 
 export type SearchParams = {
   id: string
@@ -33,7 +34,7 @@ export default async function PhotoThumbnail({
       <ButtonFavourite photo={photo} position="hidden sm:block top-1 right-1" />
       <Link href={href} className="relative block h-full w-full">
         <Image
-          src={photo.img_src}
+          src={photo.img_src || photo.imgSrc || ''}
           alt={`Photo ${photo.id.toString()} taken by Mars Rover ${
             photo.rover.name
           } on sol ${photo.sol}.`}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint": "8.39.0",
         "eslint-config-next": "^14.0.4",
         "lucide-react": "^0.291.0",
+        "mars-photo-sdk": "^1.1.0",
         "next": "^14.0.4",
         "node-fetch": "^3.3.2",
         "postcss": "^8.4.32",
@@ -4547,6 +4548,15 @@
       "integrity": "sha512-79jHlT9Je2PXSvXIBGDkItCK7In2O9iKnnSJ/bJxvIBOFaX2Ex0xEcC4fRS/g0F2uQGFejjmn2qWhwdc5wicMQ==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/mars-photo-sdk": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mars-photo-sdk/-/mars-photo-sdk-1.1.0.tgz",
+      "integrity": "sha512-kFv/0OPjNatrS1rUA8vbgZ+/RgHmq4lqAyFCbvd6X8URdoIwANG1K8BhAt5ksszRy4eYV18uXuX/GnQSYeJOKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/merge-stream": {
@@ -9814,6 +9824,11 @@
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.291.0.tgz",
       "integrity": "sha512-79jHlT9Je2PXSvXIBGDkItCK7In2O9iKnnSJ/bJxvIBOFaX2Ex0xEcC4fRS/g0F2uQGFejjmn2qWhwdc5wicMQ==",
       "requires": {}
+    },
+    "mars-photo-sdk": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mars-photo-sdk/-/mars-photo-sdk-1.1.0.tgz",
+      "integrity": "sha512-kFv/0OPjNatrS1rUA8vbgZ+/RgHmq4lqAyFCbvd6X8URdoIwANG1K8BhAt5ksszRy4eYV18uXuX/GnQSYeJOKw=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "8.39.0",
     "eslint-config-next": "^14.0.4",
     "lucide-react": "^0.291.0",
+    "mars-photo-sdk": "^1.1.0",
     "next": "^14.0.4",
     "node-fetch": "^3.3.2",
     "postcss": "^8.4.32",

--- a/types/APIResponseTypes.ts
+++ b/types/APIResponseTypes.ts
@@ -1,39 +1,3 @@
-export type Camera = {
-  id: number
-  name: CameraName
-  rover_id: number
-  full_name: FullName | FullNamePerseverance
-}
-
-export enum FullName {
-  ChemistryAndCameraComplex = 'Chemistry and Camera Complex',
-  FrontHazardAvoidanceCamera = 'Front Hazard Avoidance Camera',
-  MarsDescentImager = 'Mars Descent Imager',
-  MarsHandLensImager = 'Mars Hand Lens Imager',
-  MastCamera = 'Mast Camera',
-  NavigationCamera = 'Navigation Camera',
-  PanoramicCamera = 'Panoramic Camera',
-  RearHazardAvoidanceCamera = 'Rear Hazard Avoidance Camera',
-}
-
-export enum FullNamePerseverance {
-  RoverUpLookCamera = 'Rover Up-Look Camera',
-  RoverDownLookCamera = 'Rover Down-Look Camera',
-  DescentStageDownLookCamera = 'Descent Stage Down-Look Camera',
-  ParachuteUpLookCameraA = 'Parachute Up-Look Camera A',
-  ParachuteUpLookCameraB = 'Parachute Up-Look Camera B',
-  NavigationCameraLeft = 'Navigation Camera - Left',
-  NavigationCameraRight = 'Navigation Camera - Right',
-  MastCameraZoomRight = 'Mast Camera Zoom - Right',
-  MastCameraZoomLeft = 'Mast Camera Zoom - Left',
-  FrontHazardAvoidanceCameraLeft = 'Front Hazard Avoidance Camera - Left',
-  FrontHazardAvoidanceCameraRight = 'Front Hazard Avoidance Camera - Right',
-  RearHazardAvoidanceCameraLeft = 'Rear Hazard Avoidance Camera - Left',
-  RearHazardAvoidanceCameraRight = 'Rear Hazard Avoidance Camera - Right',
-  MEDASkycam = 'MEDA Skycam',
-  SHERLOCWATSONCamera = 'SHERLOC WATSON Camera',
-}
-
 export type CameraName =
   | CameraNameCuriosity
   | CameraNameOpportunitySpirit
@@ -83,49 +47,9 @@ export const allCameraNames = [
   ...CameraNamePerseverance,
 ] as const
 
-export type Photo = {
-  id: string
-  sol: number
-  camera: Camera
-  img_src: string
-  earth_date: string
-  rover: Rover
-}
-
-export type PhotoManifest = {
-  name: string
-  landing_date: string
-  launch_date: string
-  status: string
-  max_sol: number
-  max_date: string
-  total_photos: number
-  photos: PhotoManifestEntry[]
-}
-
-export type PhotoManifestEntry = {
-  sol: number
-  earth_date: string
-  total_photos: number
-  cameras: Camera[]
-}
-
-export type Rover = {
-  id: number
-  name: RoverName
-  landing_date: string
-  launch_date: string
-  status: Status
-}
-
 export enum RoverName {
   Curiosity = 'Curiosity',
   Opportunity = 'Opportunity',
   Perseverance = 'Perseverance',
   Spirit = 'Spirit',
-}
-
-export enum Status {
-  Active = 'active',
-  Complete = 'complete',
 }


### PR DESCRIPTION
- Install mars-photo-sdk from npm
- Refactor API layer to use SDK client instead of manual fetch
- Replace Photo and Manifest type imports with SDK types
- Update photo ID handling for SDK's number type
- Add null checks for optional SDK fields
- Remove deprecated local types (Photo, PhotoManifest, Rover, Camera)
- Keep app-specific types (RoverName enum, CameraName)